### PR TITLE
Make sure FFTW is maximally used

### DIFF
--- a/test/fftBigFloattests.jl
+++ b/test/fftBigFloattests.jl
@@ -29,4 +29,77 @@ end
     @test norm(idct(c)-idct(map(ComplexF64,c)),Inf) < 10eps()
     @test norm(idct(dct(c))-c,Inf) < 1000eps(BigFloat)
     @test norm(dct(idct(c))-c,Inf) < 1000eps(BigFloat)
+
+    # Make sure we don't accidentally hijack any FFTW plans
+    for T in (Float32, Float64)
+        @test plan_fft(rand(BigFloat,10)) isa FastTransforms.DummyPlan
+        @test plan_fft(rand(BigFloat,10), 1:1) isa FastTransforms.DummyPlan
+        @test plan_fft(rand(Complex{BigFloat},10)) isa FastTransforms.DummyPlan
+        @test plan_fft(rand(Complex{BigFloat},10), 1:1) isa FastTransforms.DummyPlan
+        @test plan_fft!(rand(Complex{BigFloat},10)) isa FastTransforms.DummyPlan
+        @test plan_fft!(rand(Complex{BigFloat},10), 1:1) isa FastTransforms.DummyPlan
+        @test !( plan_fft(rand(T,10)) isa FastTransforms.DummyPlan )
+        @test !( plan_fft(rand(T,10), 1:1) isa FastTransforms.DummyPlan )
+        @test !( plan_fft(rand(Complex{T},10)) isa FastTransforms.DummyPlan )
+        @test !( plan_fft(rand(Complex{T},10), 1:1) isa FastTransforms.DummyPlan )
+        @test !( plan_fft!(rand(Complex{T},10)) isa FastTransforms.DummyPlan )
+        @test !( plan_fft!(rand(Complex{T},10), 1:1) isa FastTransforms.DummyPlan )
+
+        @test plan_ifft(rand(T,10)) isa FFTW.ScaledPlan
+        @test plan_ifft(rand(T,10), 1:1) isa FFTW.ScaledPlan
+        @test plan_ifft(rand(Complex{T},10)) isa FFTW.ScaledPlan
+        @test plan_ifft(rand(Complex{T},10), 1:1) isa FFTW.ScaledPlan
+        @test plan_ifft!(rand(Complex{T},10)) isa FFTW.ScaledPlan
+        @test plan_ifft!(rand(Complex{T},10), 1:1) isa FFTW.ScaledPlan
+
+        @test plan_bfft(rand(BigFloat,10)) isa FastTransforms.DummyPlan
+        @test plan_bfft(rand(BigFloat,10), 1:1) isa FastTransforms.DummyPlan
+        @test plan_bfft(rand(Complex{BigFloat},10)) isa FastTransforms.DummyPlan
+        @test plan_bfft(rand(Complex{BigFloat},10), 1:1) isa FastTransforms.DummyPlan
+        @test plan_bfft!(rand(Complex{BigFloat},10)) isa FastTransforms.DummyPlan
+        @test plan_bfft!(rand(Complex{BigFloat},10), 1:1) isa FastTransforms.DummyPlan
+        @test !( plan_bfft(rand(T,10)) isa FastTransforms.DummyPlan )
+        @test !( plan_bfft(rand(T,10), 1:1) isa FastTransforms.DummyPlan )
+        @test !( plan_bfft(rand(Complex{T},10)) isa FastTransforms.DummyPlan )
+        @test !( plan_bfft(rand(Complex{T},10), 1:1) isa FastTransforms.DummyPlan )
+        @test !( plan_bfft!(rand(Complex{T},10)) isa FastTransforms.DummyPlan )
+        @test !( plan_bfft!(rand(Complex{T},10), 1:1) isa FastTransforms.DummyPlan )
+
+        @test plan_dct(rand(BigFloat,10)) isa FastTransforms.DummyPlan
+        @test plan_dct(rand(BigFloat,10), 1:1) isa FastTransforms.DummyPlan
+        @test plan_dct(rand(Complex{BigFloat},10)) isa FastTransforms.DummyPlan
+        @test plan_dct(rand(Complex{BigFloat},10), 1:1) isa FastTransforms.DummyPlan
+        @test plan_dct!(rand(Complex{BigFloat},10)) isa FastTransforms.DummyPlan
+        @test plan_dct!(rand(Complex{BigFloat},10), 1:1) isa FastTransforms.DummyPlan
+        @test !( plan_dct(rand(T,10)) isa FastTransforms.DummyPlan )
+        @test !( plan_dct(rand(T,10), 1:1) isa FastTransforms.DummyPlan )
+        @test !( plan_dct(rand(Complex{T},10)) isa FastTransforms.DummyPlan )
+        @test !( plan_dct(rand(Complex{T},10), 1:1) isa FastTransforms.DummyPlan )
+        @test !( plan_dct!(rand(Complex{T},10)) isa FastTransforms.DummyPlan )
+        @test !( plan_dct!(rand(Complex{T},10), 1:1) isa FastTransforms.DummyPlan )
+
+        @test plan_idct(rand(BigFloat,10)) isa FastTransforms.DummyPlan
+        @test plan_idct(rand(BigFloat,10), 1:1) isa FastTransforms.DummyPlan
+        @test plan_idct(rand(Complex{BigFloat},10)) isa FastTransforms.DummyPlan
+        @test plan_idct(rand(Complex{BigFloat},10), 1:1) isa FastTransforms.DummyPlan
+        @test plan_idct!(rand(Complex{BigFloat},10)) isa FastTransforms.DummyPlan
+        @test plan_idct!(rand(Complex{BigFloat},10), 1:1) isa FastTransforms.DummyPlan
+        @test !( plan_idct(rand(T,10)) isa FastTransforms.DummyPlan )
+        @test !( plan_idct(rand(T,10), 1:1) isa FastTransforms.DummyPlan )
+        @test !( plan_idct(rand(Complex{T},10)) isa FastTransforms.DummyPlan )
+        @test !( plan_idct(rand(Complex{T},10), 1:1) isa FastTransforms.DummyPlan )
+        @test !( plan_idct!(rand(Complex{T},10)) isa FastTransforms.DummyPlan )
+        @test !( plan_idct!(rand(Complex{T},10), 1:1) isa FastTransforms.DummyPlan )
+
+        @test plan_rfft(rand(BigFloat,10)) isa FastTransforms.DummyPlan
+        @test plan_rfft(rand(BigFloat,10), 1:1) isa FastTransforms.DummyPlan
+        @test plan_brfft(rand(Complex{BigFloat},10), 19) isa FastTransforms.DummyPlan
+        @test plan_brfft(rand(Complex{BigFloat},10), 19, 1:1) isa FastTransforms.DummyPlan
+        @test !( plan_rfft(rand(T,10)) isa FastTransforms.DummyPlan )
+        @test !( plan_rfft(rand(T,10), 1:1) isa FastTransforms.DummyPlan )
+        @test !( plan_brfft(rand(Complex{T},10), 19) isa FastTransforms.DummyPlan )
+        @test !( plan_brfft(rand(Complex{T},10), 19, 1:1) isa FastTransforms.DummyPlan )
+
+    end
+
 end


### PR DESCRIPTION
The previous generic FFT implementation would use generic FFT in various places even when FFTW was applicable. This is, of course, highly undesirable!

The changes here fix that, and also add tests to make sure that FFTW plans continue to be used for standard floating points. There is a runtime warning if generic fft's are used for Float32 or Float64 numbers.

The expected interface of AbstractFFTs is not entirely obvious. Some plans are only implemented for real numbers, some only for complex numbers, some plans are implemented in terms of other plans. As a result, when implementing plans for AbstractFloat we have to be careful in the typing of our implementation.