### PR TITLE
Make pochhammer more robust

### DIFF
--- a/src/specialfunctions.jl
+++ b/src/specialfunctions.jl
@@ -49,8 +49,8 @@ pochhammer(x::AbstractArray{T,1},n::Integer) where {T<:Number} = [pochhammer(x[i
 pochhammer(x::AbstractArray{T,2},n::Integer) where {T<:Number} = [pochhammer(x[i,j],n) for i=1:size(x,1),j=1:size(x,2)]
 pochhammer(x::AbstractArray{T},n::Integer) where {T<:Number} = reshape([ pochhammer(x[i],n) for i in eachindex(x) ], size(x))
 
-pochhammer(x::Number,n::Number) = newgamma(x+n)/newgamma(x)
-pochhammer(x::AbstractArray{T},n::Number) where {T<:Number} = newgamma(x+n)./newgamma(x)
+pochhammer(x::Number,n::Number) = isinteger(n) ? pochhammer(x,Int(n)) : newgamma(x+n)/newgamma(x)
+pochhammer(x::AbstractArray{T},n::Number) where {T<:Number} = isinteger(n) ? pochhammer(x,Int(n)) : newgamma.(x.+n)./newgamma.(x)
 
 function pochhammer(x::Number,n::UnitRange{T}) where T<:Real
     ret = Vector{promote_type(typeof(x),T)}(length(n))

--- a/src/specialfunctions.jl
+++ b/src/specialfunctions.jl
@@ -45,12 +45,7 @@ function pochhammer(x::Number,n::Integer)
     ret
 end
 
-pochhammer(x::AbstractArray{T,1},n::Integer) where {T<:Number} = [pochhammer(x[i],n) for i=1:length(x)]
-pochhammer(x::AbstractArray{T,2},n::Integer) where {T<:Number} = [pochhammer(x[i,j],n) for i=1:size(x,1),j=1:size(x,2)]
-pochhammer(x::AbstractArray{T},n::Integer) where {T<:Number} = reshape([ pochhammer(x[i],n) for i in eachindex(x) ], size(x))
-
 pochhammer(x::Number,n::Number) = isinteger(n) ? pochhammer(x,Int(n)) : ogamma(x)/ogamma(x+n)
-pochhammer(x::AbstractArray{T},n::Number) where {T<:Number} = isinteger(n) ? pochhammer(x,Int(n)) : ogamma.(x)./ogamma.(x.+n)
 
 function pochhammer(x::Number,n::UnitRange{T}) where T<:Real
     ret = Vector{promote_type(typeof(x),T)}(length(n))
@@ -61,13 +56,7 @@ function pochhammer(x::Number,n::UnitRange{T}) where T<:Real
     ret
 end
 
-function ogamma(x::Number)
-    if isinteger(x) && x<0
-        zero(float(x))
-    else
-        inv(gamma(x))
-    end
-end
+ogamma(x::Number) = (isinteger(x) && x<0) ? zero(float(x)) : inv(gamma(x))
 
 """
 Stirling's asymptotic series for ``\\Gamma(z)``.

--- a/src/specialfunctions.jl
+++ b/src/specialfunctions.jl
@@ -49,8 +49,8 @@ pochhammer(x::AbstractArray{T,1},n::Integer) where {T<:Number} = [pochhammer(x[i
 pochhammer(x::AbstractArray{T,2},n::Integer) where {T<:Number} = [pochhammer(x[i,j],n) for i=1:size(x,1),j=1:size(x,2)]
 pochhammer(x::AbstractArray{T},n::Integer) where {T<:Number} = reshape([ pochhammer(x[i],n) for i in eachindex(x) ], size(x))
 
-pochhammer(x::Number,n::Number) = isinteger(n) ? pochhammer(x,Int(n)) : newgamma(x+n)/newgamma(x)
-pochhammer(x::AbstractArray{T},n::Number) where {T<:Number} = isinteger(n) ? pochhammer(x,Int(n)) : newgamma.(x.+n)./newgamma.(x)
+pochhammer(x::Number,n::Number) = isinteger(n) ? pochhammer(x,Int(n)) : ogamma(x)/ogamma(x+n)
+pochhammer(x::AbstractArray{T},n::Number) where {T<:Number} = isinteger(n) ? pochhammer(x,Int(n)) : ogamma.(x)./newgamma.(x.+n)
 
 function pochhammer(x::Number,n::UnitRange{T}) where T<:Real
     ret = Vector{promote_type(typeof(x),T)}(length(n))
@@ -61,11 +61,11 @@ function pochhammer(x::Number,n::UnitRange{T}) where T<:Real
     ret
 end
 
-function newgamma(x::Number)
+function ogamma(x::Number)
     if isinteger(x) && x<0
-        Inf
+        0.0
     else
-        gamma(x)
+        1.0/gamma(x)
     end
 end
 

--- a/src/specialfunctions.jl
+++ b/src/specialfunctions.jl
@@ -50,7 +50,7 @@ pochhammer(x::AbstractArray{T,2},n::Integer) where {T<:Number} = [pochhammer(x[i
 pochhammer(x::AbstractArray{T},n::Integer) where {T<:Number} = reshape([ pochhammer(x[i],n) for i in eachindex(x) ], size(x))
 
 pochhammer(x::Number,n::Number) = isinteger(n) ? pochhammer(x,Int(n)) : ogamma(x)/ogamma(x+n)
-pochhammer(x::AbstractArray{T},n::Number) where {T<:Number} = isinteger(n) ? pochhammer(x,Int(n)) : ogamma.(x)./newgamma.(x.+n)
+pochhammer(x::AbstractArray{T},n::Number) where {T<:Number} = isinteger(n) ? pochhammer(x,Int(n)) : ogamma.(x)./ogamma.(x.+n)
 
 function pochhammer(x::Number,n::UnitRange{T}) where T<:Real
     ret = Vector{promote_type(typeof(x),T)}(length(n))

--- a/src/specialfunctions.jl
+++ b/src/specialfunctions.jl
@@ -63,9 +63,9 @@ end
 
 function ogamma(x::Number)
     if isinteger(x) && x<0
-        0.0
+        zero(float(x))
     else
-        1.0/gamma(x)
+        inv(gamma(x))
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,3 +28,5 @@ include("butterflytests.jl")
 include("sphericalharmonics/sphericalharmonictests.jl")
 
 include("toeplitztests.jl")
+
+include("specialfunctionstests.jl")

--- a/test/specialfunctionstests.jl
+++ b/test/specialfunctionstests.jl
@@ -13,7 +13,7 @@ const sqrtpi = 1.772453850905516027298
     @test pochhammer(-5,3) == -60
     @test pochhammer(-1,-0.5) == 0
     @test 1.0/pochhammer(-0.5,-0.5) == 0
-    @test pochhammer(-1+0im,-1) == -2
+    @test pochhammer(-1+0im,-1) == -0.5
     @test pochhammer([2,-5,-1],3) == [24,-60,0]
     @test pochhammer([-1,-0.5],-0.5) == [0,-Inf]
 end

--- a/test/specialfunctionstests.jl
+++ b/test/specialfunctionstests.jl
@@ -5,4 +5,9 @@ using Compat.Test
     @test pochhammer(2,3) == 24
     @test pochhammer(0.5,3) == 0.5*1.5*2.5
     @test pochhammer(0.5,0.5) == 1/sqrtpi
+    @test pochhammer(0,1) == 0
+    @test pochhammer(-1,2) == 0
+    @test pochhammer(-5,3) == -60
+    @test pochhammer(-1,-0.5) == 0
+    @test pochhammer(-0.5,-0.5) == Inf
 end

--- a/test/specialfunctionstests.jl
+++ b/test/specialfunctionstests.jl
@@ -13,4 +13,6 @@ const sqrtpi = 1.772453850905516027298
     @test pochhammer(-5,3) == -60
     @test pochhammer(-1,-0.5) == 0
     @test 1.0/pochhammer(-0.5,-0.5) == 0
+    @test pochhammer([2,-5,-1],3) == [24,-60,0]
+    @test pochhammer([-1,-0.5],-0.5) == [0,-Inf]
 end

--- a/test/specialfunctionstests.jl
+++ b/test/specialfunctionstests.jl
@@ -1,0 +1,5 @@
+using FastTransforms
+
+@testset "Pochhammer" begin
+
+end

--- a/test/specialfunctionstests.jl
+++ b/test/specialfunctionstests.jl
@@ -2,6 +2,8 @@ using FastTransforms
 using Compat.Test
 import FastTransforms.pochhammer
 
+const sqrtpi = 1.772453850905516027298
+
 @testset "Pochhammer" begin
     @test pochhammer(2,3) == 24
     @test pochhammer(0.5,3) == 0.5*1.5*2.5
@@ -10,5 +12,5 @@ import FastTransforms.pochhammer
     @test pochhammer(-1,2) == 0
     @test pochhammer(-5,3) == -60
     @test pochhammer(-1,-0.5) == 0
-    @test pochhammer(-0.5,-0.5) == Inf
+    @test 1.0/pochhammer(-0.5,-0.5) == 0
 end

--- a/test/specialfunctionstests.jl
+++ b/test/specialfunctionstests.jl
@@ -4,5 +4,5 @@ using Compat.Test
 @testset "Pochhammer" begin
     @test pochhammer(2,3) == 24
     @test pochhammer(0.5,3) == 0.5*1.5*2.5
-    @test pochhammer(0.5,0.5) == 1/sqrt(pi)
+    @test pochhammer(0.5,0.5) == 1/sqrtpi
 end

--- a/test/specialfunctionstests.jl
+++ b/test/specialfunctionstests.jl
@@ -1,5 +1,6 @@
 using FastTransforms
 using Compat.Test
+import FastTransforms.pochhammer
 
 @testset "Pochhammer" begin
     @test pochhammer(2,3) == 24

--- a/test/specialfunctionstests.jl
+++ b/test/specialfunctionstests.jl
@@ -1,5 +1,8 @@
 using FastTransforms
+using Compat.Test
 
 @testset "Pochhammer" begin
-
+    @test pochhammer(2,3) == 24
+    @test pochhammer(0.5,3) == 0.5*1.5*2.5
+    @test pochhammer(0.5,0.5) == 1/sqrt(pi)
 end

--- a/test/specialfunctionstests.jl
+++ b/test/specialfunctionstests.jl
@@ -14,6 +14,4 @@ const sqrtpi = 1.772453850905516027298
     @test pochhammer(-1,-0.5) == 0
     @test 1.0/pochhammer(-0.5,-0.5) == 0
     @test pochhammer(-1+0im,-1) == -0.5
-    @test pochhammer([2,-5,-1],3) == [24,-60,0]
-    @test pochhammer([-1,-0.5],-0.5) == [0,-Inf]
 end

--- a/test/specialfunctionstests.jl
+++ b/test/specialfunctionstests.jl
@@ -13,6 +13,7 @@ const sqrtpi = 1.772453850905516027298
     @test pochhammer(-5,3) == -60
     @test pochhammer(-1,-0.5) == 0
     @test 1.0/pochhammer(-0.5,-0.5) == 0
+    @test pochhammer(-1+0im,-1) == -2
     @test pochhammer([2,-5,-1],3) == [24,-60,0]
     @test pochhammer([-1,-0.5],-0.5) == [0,-Inf]
 end


### PR DESCRIPTION
`pochhammer `can now deal with arbitrary `::Number` without throwing unexpected errors.
I did this by adding a modified version of `gamma` function named `newgamma` which returns `Inf` at negative integers.

Added a test file.

Edit: following @dlfivefifty 's suggestion, I used `ogamma` which returns 0 at negative integers.