### PR TITLE
Feat libfasttransforms v0.3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ jobs:
       arch: arm64
   allow_failures:
     - julia: nightly
+    - arch: arm64
 notifications:
   email: false
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,21 +7,20 @@ arch:
   - x64
   - x86
   - arm64
-matrix:
+julia:
+  - 1.3
+  - 1.4
+  - nightly
+jobs:
   exclude:
     - os: freebsd
       arch: x86
     - os: freebsd
       arch: arm64
-julia:
-  - 1.3
-  - 1.4
-  - nightly
-notifications:
-  email: false
-jobs:
   allow_failures:
     - julia: nightly
+notifications:
+  email: false
 cache:
   directories:
     - $HOME/.julia/artifacts

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,17 @@
 # Documentation: http://docs.travis-ci.com/user/languages/julia/
 language: julia
-jobs:
-  include:
+os:
+  - freebsd
+  - linux
+arch:
+  - x64
+  - x86
+  - arm64
+matrix:
+  exclude:
     - os: freebsd
-    - os: linux
-      arch: amd64
-    - os: linux
+      arch: x86
+    - os: freebsd
       arch: arm64
 julia:
   - 1.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
 # Documentation: http://docs.travis-ci.com/user/languages/julia/
 language: julia
-os:
-  - freebsd
+jobs:
+  include:
+    - os: freebsd
+    - os: linux
+      arch: amd64
+    - os: linux
+      arch: arm64
 julia:
   - 1.3
   - 1.4

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FastTransforms"
 uuid = "057dd010-8810-581a-b7be-e3fc3b93f78c"
-version = "0.9.3"
+version = "0.9.4"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
@@ -25,7 +25,7 @@ BinaryProvider = "0.5"
 DSP = "0.6"
 FFTW = "1"
 FastGaussQuadrature = "0.4"
-FastTransforms_jll = "0.3.2"
+FastTransforms_jll = "0.3.3"
 FillArrays = "0.8"
 Reexport = "0.2"
 SpecialFunctions = "0.8, 0.9, 0.10"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This package provides a Julia wrapper for the [C library](https://github.com/Mik
 
 ## Installation
 
-Installation, which uses [BinaryBuilder](https://github.com/JuliaPackaging/BinaryBuilder.jl) for Intel processors (Sandybridge and beyond), may be as straightforward as:
+Installation, which uses [BinaryBuilder](https://github.com/JuliaPackaging/BinaryBuilder.jl) for all of Julia's supported platforms (in particular Sandybridge Intel processors and beyond), may be as straightforward as:
 
 ```julia
 pkg> add FastTransforms

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,11 +1,7 @@
 using BinaryProvider
 import Libdl
 
-version = v"0.3.2"
-
-if arch(platform_key_abi()) != :x86_64
-    @warn "FastTransforms has only been tested on x86_64 architectures."
-end
+version = v"0.3.3"
 
 const extension = Sys.isapple() ? "dylib" : Sys.islinux() ? "so" : Sys.iswindows() ? "dll" : ""
 
@@ -15,15 +11,14 @@ print_error() = error(
     print_platform_error(platform_key_abi())
 )
 
-print_platform_error(p::Platform) = "On $(BinaryProvider.platform_name(p)), please consider opening a pull request to add support.\n"
-print_platform_error(p::MacOS) = "On MacOS\n\tbrew install gcc@8 fftw mpfr\n"
-print_platform_error(p::Linux) = "On Linux\n\tsudo apt-get install gcc-8 libblas-dev libopenblas-base libfftw3-dev libmpfr-dev\n"
+print_platform_error(p::Platform) = "On $(BinaryProvider.platform_name(p)), please consider opening a pull request to add support to build from source.\n"
+print_platform_error(p::MacOS) = "On MacOS\n\tbrew install libomp fftw mpfr\n"
+print_platform_error(p::Linux) = "On Linux\n\tsudo apt-get install libomp-dev libblas-dev libopenblas-base libfftw3-dev libmpfr-dev\n"
 print_platform_error(p::Windows) = "On Windows\n\tvcpkg install openblas:x64-windows fftw3[core,threads]:x64-windows mpir:x64-windows mpfr:x64-windows\n"
 
 ft_build_from_source = get(ENV, "FT_BUILD_FROM_SOURCE", "false")
 if ft_build_from_source == "true"
     make = Sys.iswindows() ? "mingw32-make" : "make"
-    compiler = Sys.isapple() ? "CC=gcc-8" : "CC=gcc"
     flags = Sys.isapple() ? "FT_USE_APPLEBLAS=1" : Sys.iswindows() ? "FT_FFTW_WITH_COMBINED_THREADS=1" : ""
     script = """
         set -e
@@ -37,8 +32,8 @@ if ft_build_from_source == "true"
             git clone -b v$version https://github.com/MikaelSlevinsky/FastTransforms.git FastTransforms
         fi
         cd FastTransforms
-        $make assembly $compiler
-        $make lib $compiler $flags
+        $make assembly
+        $make lib $flags
         cd ..
         mv -f FastTransforms/libfasttransforms.$extension libfasttransforms.$extension
     """

--- a/src/clenshaw.jl
+++ b/src/clenshaw.jl
@@ -4,7 +4,7 @@
 evaluates the orthogonal polynomials at points `x`,
 where `A`, `B`, and `C` are `AbstractVector`s containing the recurrence coefficients
 as defined in DLMF,
-overwriting `v` with the results.   
+overwriting `v` with the results.
 """
 function forwardrecurrence!(v::AbstractVector{T}, A::AbstractVector, B::AbstractVector, C::AbstractVector, x) where T
     N = length(v)
@@ -51,7 +51,7 @@ where `A`, `B`, and `C` are `AbstractVector`s containing the recurrence coeffici
 as defined in DLMF,
 overwriting `x` with the results.
 """
-clenshaw!(c::AbstractVector, A::AbstractVector, B::AbstractVector, C::AbstractVector, x::AbstractVector) = 
+clenshaw!(c::AbstractVector, A::AbstractVector, B::AbstractVector, C::AbstractVector, x::AbstractVector) =
     clenshaw!(c, A, B, C, x, Ones{eltype(x)}(length(x)), x)
 
 
@@ -85,7 +85,7 @@ where `A`, `B`, and `C` are `AbstractVector`s containing the recurrence coeffici
 as defined in DLMF.
 `x` may also be a single `Number`.
 """
-     
+
 function clenshaw(c::AbstractVector, A::AbstractVector, B::AbstractVector, C::AbstractVector, x::Number)
     N = length(c)
     T = promote_type(eltype(c),eltype(A),eltype(B),eltype(C),typeof(x))
@@ -104,7 +104,7 @@ function clenshaw(c::AbstractVector, A::AbstractVector, B::AbstractVector, C::Ab
 end
 
 
-clenshaw(c::AbstractVector, A::AbstractVector, B::AbstractVector, C::AbstractVector, x::AbstractVector) = 
+clenshaw(c::AbstractVector, A::AbstractVector, B::AbstractVector, C::AbstractVector, x::AbstractVector) =
     clenshaw!(c, A, B, C, copy(x))
 
 ###
@@ -157,4 +157,3 @@ function clenshaw(c::AbstractVector, x::Number)
 end
 
 clenshaw(c::AbstractVector, x::AbstractVector) = clenshaw!(c, copy(x))
-


### PR DESCRIPTION
The new binaries support all Julia supported platforms from BinaryBuilder.jl

Adds "allowed_failures" testing on aarch64-linux (since they sometimes timeout).

Update build from source script, no longer need a specific GCC, can be built from Clang, provided one has libomp.