### PR TITLE
Correct array index in example

### DIFF
--- a/examples/spinweighted.jl
+++ b/examples/spinweighted.jl
@@ -44,7 +44,7 @@ norm(U⁰) ≈ sqrt(4π)
 # Spin can be incremented by applying ð, either on the spin-$0$ coefficients:
 U¹c = zero(U⁰)
 for n in 1:N-1
-    U¹c[n, 1] = sqrt(n*(n+1))*U⁰[n+1, 1]
+    U¹c[n+1, 1] = sqrt(n*(n+1))*U⁰[n+1, 1]
 end
 for m in 1:M÷2
     for n in 0:N-1


### PR DESCRIPTION
If I understand the array layout correctly, then the eth operator should not affect the location where the `l=0` modes are stored.