### PR TITLE
Use `pkgdir`

### DIFF
--- a/examples/disk.jl
+++ b/examples/disk.jl
@@ -20,7 +20,7 @@
 # [documentation](https://MikaelSlevinsky.github.io/FastTransforms).
 
 using FastTransforms, LinearAlgebra, Plots
-const GENFIGS = joinpath(dirname(dirname(pathof(FastTransforms))), "docs/src/generated")
+const GENFIGS = joinpath(pkgdir(FastTransforms), "docs/src/generated")
 !isdir(GENFIGS) && mkdir(GENFIGS)
 plotlyjs()
 

--- a/examples/sphere.jl
+++ b/examples/sphere.jl
@@ -33,7 +33,7 @@ function threshold!(A::AbstractArray, ϵ)
 end
 
 using FastTransforms, LinearAlgebra, Plots
-const GENFIGS = joinpath(dirname(dirname(pathof(FastTransforms))), "docs/src/generated")
+const GENFIGS = joinpath(pkgdir(FastTransforms), "docs/src/generated")
 !isdir(GENFIGS) && mkdir(GENFIGS)
 plotlyjs()
 

--- a/examples/triangle.jl
+++ b/examples/triangle.jl
@@ -24,7 +24,7 @@
 # [documentation](https://MikaelSlevinsky.github.io/FastTransforms).
 
 using FastTransforms, LinearAlgebra, Plots
-const GENFIGS = joinpath(dirname(dirname(pathof(FastTransforms))), "docs/src/generated")
+const GENFIGS = joinpath(pkgdir(FastTransforms), "docs/src/generated")
 !isdir(GENFIGS) && mkdir(GENFIGS)
 plotlyjs()
 


### PR DESCRIPTION
Since [Julia 1.4](https://github.com/JuliaLang/julia/blob/v1.4.2/NEWS.md), there is the very convenient `pkgdir` which many people overlook. Via code searches, I noticed that this repository uses some `dirname(dirname(pathof(FastTransforms)))` which is the same as `pkgdir(FastTransforms)`, so this PR proposes to replace that.