### PR TITLE
FTPlan times StridedArray

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FastTransforms"
 uuid = "057dd010-8810-581a-b7be-e3fc3b93f78c"
-version = "0.14.1"
+version = "0.14.2"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/test/libfasttransformstests.jl
+++ b/test/libfasttransformstests.jl
@@ -23,6 +23,14 @@ FastTransforms.ft_set_num_threads(ceil(Int, Base.Sys.CPU_THREADS/2))
         @test f ≈ fd
     end
 
+    @testset "contiguity sanity checks" begin
+        for v in Any[rand(2), rand(2,2)], s in Any[v, view(v, CartesianIndices(v)), reshape(v, Val(3))]
+            @test FastTransforms.iscontiguous(rand(2))
+            @test FastTransforms.iscontiguous(rand(2,2))
+        end
+        @test !FastTransforms.iscontiguous(transpose(rand(2,2)))
+    end
+
     α, β, γ, δ, λ, μ = 0.1, 0.2, 0.3, 0.4, 0.5, 0.6
     function test_1d_plans(p1, p2, x)
         y = p1*x

--- a/test/libfasttransformstests.jl
+++ b/test/libfasttransformstests.jl
@@ -28,9 +28,11 @@ FastTransforms.ft_set_num_threads(ceil(Int, Base.Sys.CPU_THREADS/2))
         y = p1*x
         z = p2*y
         @test z ≈ x
+
         y = p1*view(x, :)
         z = p2*view(y, :)
         @test z ≈ x
+
         y = p1*x
         z = p1'y
         y = transpose(p1)*z
@@ -38,6 +40,15 @@ FastTransforms.ft_set_num_threads(ceil(Int, Base.Sys.CPU_THREADS/2))
         y = p1'\z
         z = p1\y
         @test z ≈ x
+
+        y = p1*view(x, :)
+        z = p1'view(y, :)
+        y = transpose(p1)*view(z, :)
+        z = transpose(p1)\view(y, :)
+        y = p1'\view(z, :)
+        z = p1\view(y, :)
+        @test z ≈ x
+
         y = p2*x
         z = p2'y
         y = transpose(p2)*z
@@ -45,9 +56,11 @@ FastTransforms.ft_set_num_threads(ceil(Int, Base.Sys.CPU_THREADS/2))
         y = p2'\z
         z = p2\y
         @test z ≈ x
+
         P = p1*I
         Q = p2*P
         @test Q ≈ I
+
         P = p1*I
         Q = p1'P
         P = transpose(p1)*Q
@@ -55,6 +68,7 @@ FastTransforms.ft_set_num_threads(ceil(Int, Base.Sys.CPU_THREADS/2))
         P = p1'\Q
         Q = p1\P
         @test Q ≈ I
+
         P = p2*I
         Q = p2'P
         P = transpose(p2)*Q

--- a/test/libfasttransformstests.jl
+++ b/test/libfasttransformstests.jl
@@ -28,6 +28,9 @@ FastTransforms.ft_set_num_threads(ceil(Int, Base.Sys.CPU_THREADS/2))
         y = p1*x
         z = p2*y
         @test z ≈ x
+        y = p1*view(x, :)
+        z = p2*view(y, :)
+        @test z ≈ x
         y = p1*x
         z = p1'y
         y = transpose(p1)*z


### PR DESCRIPTION
Fixes #178. Now, the following works:
```julia
julia> v = rand(ComplexF64, 10);

julia> f = plan_leg2cheb(v);

julia> f * view(v, :) == f * v
true
```
I've conservatively required the arrays to be contiguous, as judged from their sizes and strides.