### PR TITLE
allow views in *, \ and contiguous lmul! and ldiv!

### DIFF
--- a/examples/nonlocaldiffusion.jl
+++ b/examples/nonlocaldiffusion.jl
@@ -70,7 +70,7 @@ function evaluate_lambda(n::Integer, alpha::T, delta::T) where T
 
     p = plan_jac2jac(T, n-1, zero(T), zero(T), alpha, zero(T))
 
-    lambda[2:end] .= p'lambda[2:end]
+    lmul!(p', view(lambda, 2:n))
 
     for i = 2:n-1
         lambda[i+1] = ((2i-1)*lambda[i+1] + (i-1)*lambda[i])/i


### PR DESCRIPTION
Alternate way to close #178 instead of #179.

Technically, all that #178 needs is to finish https://github.com/JuliaApproximation/FastTransforms.jl/commit/3ba4ee3b717598a7ed89fbe675e010c01c415bb9

but this PR goes further and allows unit strided array calls with `lmul!` and `ldiv!` (in-place transforms).  Later, the C library can be expanded to include more general strides.