### PR TITLE
Temporary upper bound on FFTW to < v1.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FastTransforms"
 uuid = "057dd010-8810-581a-b7be-e3fc3b93f78c"
-version = "0.14.9"
+version = "0.14.10"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
@@ -18,7 +18,7 @@ ToeplitzMatrices = "c751599d-da0a-543b-9d20-d0a503d91d24"
 
 [compat]
 AbstractFFTs = "1.0"
-FFTW = "1"
+FFTW = "1 - 1.5"
 FastGaussQuadrature = "0.4, 0.5"
 FastTransforms_jll = "0.6.2"
 FillArrays = "0.9, 0.10, 0.11, 0.12, 0.13"


### PR DESCRIPTION
FFTW v1.6 changes the type parameters of an r2rFFTWPlan, so this package breaks on that. This PR temporarily limits this package to older versions of FFTW while the issue is resolved.