### PR TITLE
Make ChebyshevTransformPlan compatible with FFTW v1.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FastTransforms"
 uuid = "057dd010-8810-581a-b7be-e3fc3b93f78c"
-version = "0.14.9"
+version = "0.14.11"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
@@ -18,7 +18,7 @@ ToeplitzMatrices = "c751599d-da0a-543b-9d20-d0a503d91d24"
 
 [compat]
 AbstractFFTs = "1.0"
-FFTW = "1"
+FFTW = "1.6"
 FastGaussQuadrature = "0.4, 0.5"
 FastTransforms_jll = "0.6.2"
 FillArrays = "0.9, 0.10, 0.11, 0.12, 0.13"

--- a/src/chebyshevtransform.jl
+++ b/src/chebyshevtransform.jl
@@ -15,35 +15,35 @@ struct ChebyshevTransformPlan{T,kind,K,inplace,N,R} <: ChebyshevPlan{T}
     ChebyshevTransformPlan{T,kind,K,inplace,N,R}() where {T,kind,K,inplace,N,R} = new{T,kind,K,inplace,N,R}()
 end
 
-ChebyshevTransformPlan{T,kind,K}(plan::FFTW.r2rFFTWPlan{T,K,inplace,N,R}) where {T,kind,K,inplace,N,R} =
+ChebyshevTransformPlan{T,kind}(plan::FFTW.r2rFFTWPlan{T,K,inplace,N,R}) where {T,kind,K,inplace,N,R} =
     ChebyshevTransformPlan{T,kind,K,inplace,N,R}(plan)
 
 # jump through some hoops to make inferrable
-@inline kindtuple(KIND,N) = ntuple(_ -> KIND,N)
-@inline kindtuple(KIND,N,::Integer) = (KIND,)
+@inline kindtuple(N) = typeof(ntuple(Int32,N))
+@inline kindtuple(N,region...) = Vector{Int32}
 function plan_chebyshevtransform!(x::AbstractArray{T,N}, ::Val{1}, dims...; kws...) where {T<:fftwNumber,N}
     if isempty(x)
-        ChebyshevTransformPlan{T,1,kindtuple(FIRSTKIND,N,dims...),true,N,isempty(dims) ? UnitRange{Int} : typeof(dims)}()
+        ChebyshevTransformPlan{T,1,kindtuple(N,dims...),true,N,isempty(dims) ? NTuple{N,Int} : typeof(dims[1])}()
     else
-        ChebyshevTransformPlan{T,1,kindtuple(FIRSTKIND,N,dims...)}(FFTW.plan_r2r!(x, FIRSTKIND, dims...; kws...))
+        ChebyshevTransformPlan{T,1}(FFTW.plan_r2r!(x, FIRSTKIND, dims...; kws...))
     end
 end
 function plan_chebyshevtransform!(x::AbstractArray{T,N}, ::Val{2}, dims...; kws...) where {T<:fftwNumber,N}
     any(≤(1),size(x)) && throw(ArgumentError("Array must contain at least 2 entries"))
-    ChebyshevTransformPlan{T,2,kindtuple(SECONDKIND,N,dims...)}(FFTW.plan_r2r!(x, SECONDKIND, dims...; kws...))
+    ChebyshevTransformPlan{T,2}(FFTW.plan_r2r!(x, SECONDKIND, dims...; kws...))
 end
 
 
 function plan_chebyshevtransform(x::AbstractArray{T,N}, ::Val{1}, dims...; kws...) where {T<:fftwNumber,N}
     if isempty(x)
-        ChebyshevTransformPlan{T,1,kindtuple(FIRSTKIND,N,dims...),false,N,isempty(dims) ? UnitRange{Int} : typeof(dims)}()
+        ChebyshevTransformPlan{T,1,kindtuple(N,dims...),false,N,isempty(dims) ? NTuple{N,Int} : typeof(dims[1])}()
     else
-        ChebyshevTransformPlan{T,1,kindtuple(FIRSTKIND,N,dims...)}(FFTW.plan_r2r(x, FIRSTKIND, dims...; kws...))
+        ChebyshevTransformPlan{T,1}(FFTW.plan_r2r(x, FIRSTKIND, dims...; kws...))
     end
 end
 function plan_chebyshevtransform(x::AbstractArray{T,N}, ::Val{2}, dims...; kws...) where {T<:fftwNumber,N}
     any(≤(1),size(x)) && throw(ArgumentError("Array must contain at least 2 entries"))
-    ChebyshevTransformPlan{T,2,kindtuple(SECONDKIND,N,dims...)}(FFTW.plan_r2r(x, SECONDKIND, dims...; kws...))
+    ChebyshevTransformPlan{T,2}(FFTW.plan_r2r(x, SECONDKIND, dims...; kws...))
 end
 
 plan_chebyshevtransform!(x::AbstractArray, dims...; kws...) = plan_chebyshevtransform!(x, Val(1), dims...; kws...)
@@ -143,7 +143,7 @@ function _prod_size(sz, d)
 end
 
 
-@inline function _cheb1_rescale!(d::UnitRange, y::AbstractArray)
+@inline function _cheb1_rescale!(d, y::AbstractArray)
     for k in d
         ldiv_dim_begin!(2, k, y)
     end
@@ -175,7 +175,7 @@ function _cheb2_rescale!(d::Number, y::AbstractArray)
 end
 
 # TODO: higher dimensional arrays
-function _cheb2_rescale!(d::UnitRange, y::AbstractArray)
+function _cheb2_rescale!(d, y::AbstractArray)
     for k in d
         ldiv_dim_begin!(2, k, y)
         ldiv_dim_end!(2, k, y)
@@ -229,18 +229,18 @@ struct IChebyshevTransformPlan{T,kind,K,inplace,N,R} <: ChebyshevPlan{T}
     IChebyshevTransformPlan{T,kind,K,inplace,N,R}() where {T,kind,K,inplace,N,R} = new{T,kind,K,inplace,N,R}()
 end
 
-IChebyshevTransformPlan{T,kind,K}(F::FFTW.r2rFFTWPlan{T,K,inplace,N,R}) where {T,kind,K,inplace,N,R} =
+IChebyshevTransformPlan{T,kind}(F::FFTW.r2rFFTWPlan{T,K,inplace,N,R}) where {T,kind,K,inplace,N,R} =
     IChebyshevTransformPlan{T,kind,K,inplace,N,R}(F)
 
 
 
 # second kind Chebyshev transforms share a plan with their inverse
 # so we support this via inv
-inv(P::ChebyshevTransformPlan{T,2,K}) where {T,K} = IChebyshevTransformPlan{T,2,K}(P.plan)
-inv(P::IChebyshevTransformPlan{T,2,K}) where {T,K} = ChebyshevTransformPlan{T,2,K}(P.plan)
+inv(P::ChebyshevTransformPlan{T,2}) where {T} = IChebyshevTransformPlan{T,2}(P.plan)
+inv(P::IChebyshevTransformPlan{T,2}) where {T} = ChebyshevTransformPlan{T,2}(P.plan)
 
-inv(P::ChebyshevTransformPlan{T,1,K,inplace,N}) where {T,K,inplace,N} = IChebyshevTransformPlan{T,1,kindtuple(IFIRSTKIND,N,P.plan.region...)}(inv(P.plan).p)
-inv(P::IChebyshevTransformPlan{T,1,K,inplace,N}) where {T,K,inplace,N} = ChebyshevTransformPlan{T,1,kindtuple(FIRSTKIND,N,P.plan.region...)}(inv(P.plan).p)
+inv(P::ChebyshevTransformPlan{T,1}) where {T} = IChebyshevTransformPlan{T,1}(inv(P.plan).p)
+inv(P::IChebyshevTransformPlan{T,1}) where {T} = ChebyshevTransformPlan{T,1}(inv(P.plan).p)
 
 
 
@@ -250,9 +250,9 @@ inv(P::IChebyshevTransformPlan{T,1,K,inplace,N}) where {T,K,inplace,N} = Chebysh
 
 function plan_ichebyshevtransform!(x::AbstractArray{T,N}, ::Val{1}, dims...; kws...) where {T<:fftwNumber,N}
     if isempty(x)
-        IChebyshevTransformPlan{T,1,kindtuple(IFIRSTKIND,N,dims...),true,N,isempty(dims) ? UnitRange{Int} : typeof(dims)}()
+        IChebyshevTransformPlan{T,1,kindtuple(N,dims...),true,N,isempty(dims) ? NTuple{N,Int} : typeof(dims[1])}()
     else
-        IChebyshevTransformPlan{T,1,kindtuple(IFIRSTKIND,N,dims...)}(FFTW.plan_r2r!(x, IFIRSTKIND, dims...; kws...))
+        IChebyshevTransformPlan{T,1}(FFTW.plan_r2r!(x, IFIRSTKIND, dims...; kws...))
     end
 end
 
@@ -262,9 +262,9 @@ end
 
 function plan_ichebyshevtransform(x::AbstractArray{T,N}, ::Val{1}, dims...; kws...) where {T<:fftwNumber,N}
     if isempty(x)
-        IChebyshevTransformPlan{T,1,kindtuple(IFIRSTKIND,N,dims...),false,N,isempty(dims) ? UnitRange{Int} : typeof(dims)}()
+        IChebyshevTransformPlan{T,1,kindtuple(N,dims...),false,N,isempty(dims) ? NTuple{N,Int} : typeof(dims[1])}()
     else
-        IChebyshevTransformPlan{T,1,kindtuple(IFIRSTKIND,N,dims...)}(FFTW.plan_r2r(x, IFIRSTKIND, dims...; kws...))
+        IChebyshevTransformPlan{T,1}(FFTW.plan_r2r(x, IFIRSTKIND, dims...; kws...))
     end
 end
 
@@ -279,7 +279,7 @@ plan_ichebyshevtransform(x::AbstractArray, dims...; kws...) = plan_ichebyshevtra
     lmul_dim_begin!(2, d, x)
     x
 end
-@inline function _icheb1_prescale!(d::UnitRange, x::AbstractArray)
+@inline function _icheb1_prescale!(d, x::AbstractArray)
     for k in d
         _icheb1_prescale!(k, x)
     end
@@ -290,7 +290,7 @@ end
     x
 end
 
-@inline function _icheb1_postscale!(d::UnitRange, x::AbstractArray)
+@inline function _icheb1_postscale!(d, x::AbstractArray)
     for k in d
         _icheb1_postscale!(k, x)
     end
@@ -321,7 +321,7 @@ end
     lmul_dim_end!(2, d, x)
     x
 end
-@inline function _icheb2_prescale!(d::UnitRange, x::AbstractArray)
+@inline function _icheb2_prescale!(d, x::AbstractArray)
     for k in d
         _icheb2_prescale!(k, x)
     end
@@ -333,7 +333,7 @@ end
     ldiv_dim_end!(2, d, x)
     x
 end
-@inline function _icheb2_postrescale!(d::UnitRange, x::AbstractArray)
+@inline function _icheb2_postrescale!(d, x::AbstractArray)
     for k in d
         _icheb2_postrescale!(k, x)
     end
@@ -344,7 +344,7 @@ end
     lmul!(convert(T, size(y,d) - 1)/2, y)
     y
 end
-@inline function _icheb2_rescale!(d::UnitRange, y::AbstractArray{T}) where T
+@inline function _icheb2_rescale!(d, y::AbstractArray{T}) where T
     _icheb2_prescale!(d, y)
     lmul!(_prod_size(convert.(T, size(y) .- 1)./2, d), y)
     y
@@ -384,32 +384,32 @@ struct ChebyshevUTransformPlan{T,kind,K,inplace,N,R} <: ChebyshevPlan{T}
     ChebyshevUTransformPlan{T,kind,K,inplace,N,R}() where {T,kind,K,inplace,N,R} = new{T,kind,K,inplace,N,R}()
 end
 
-ChebyshevUTransformPlan{T,kind,K}(plan::FFTW.r2rFFTWPlan{T,K,inplace,N,R}) where {T,kind,K,inplace,N,R} =
+ChebyshevUTransformPlan{T,kind}(plan::FFTW.r2rFFTWPlan{T,K,inplace,N,R}) where {T,kind,K,inplace,N,R} =
     ChebyshevUTransformPlan{T,kind,K,inplace,N,R}(plan)
 
 
 function plan_chebyshevutransform!(x::AbstractArray{T,N}, ::Val{1}, dims...; kws...) where {T<:fftwNumber,N}
     if isempty(x)
-        ChebyshevUTransformPlan{T,1,kindtuple(UFIRSTKIND,N,dims...),true,N,isempty(dims) ? UnitRange{Int} : typeof(dims)}()
+        ChebyshevUTransformPlan{T,1,kindtuple(N,dims...),true,N,isempty(dims) ? NTuple{N,Int} : typeof(dims[1])}()
     else
-        ChebyshevUTransformPlan{T,1,kindtuple(UFIRSTKIND,N,dims...)}(FFTW.plan_r2r!(x, UFIRSTKIND, dims...; kws...))
+        ChebyshevUTransformPlan{T,1}(FFTW.plan_r2r!(x, UFIRSTKIND, dims...; kws...))
     end
 end
 function plan_chebyshevutransform!(x::AbstractArray{T,N}, ::Val{2}, dims...; kws...) where {T<:fftwNumber,N}
     any(≤(1),size(x)) && throw(ArgumentError("Array must contain at least 2 entries"))
-    ChebyshevUTransformPlan{T,2,kindtuple(USECONDKIND,N,dims...)}(FFTW.plan_r2r!(x, USECONDKIND, dims...; kws...))
+    ChebyshevUTransformPlan{T,2}(FFTW.plan_r2r!(x, USECONDKIND, dims...; kws...))
 end
 
 function plan_chebyshevutransform(x::AbstractArray{T,N}, ::Val{1}, dims...; kws...) where {T<:fftwNumber,N}
     if isempty(x)
-        ChebyshevUTransformPlan{T,1,kindtuple(UFIRSTKIND,N,dims...),false,N,isempty(dims) ? UnitRange{Int} : typeof(dims)}()
+        ChebyshevUTransformPlan{T,1,kindtuple(N,dims...),false,N,isempty(dims) ? NTuple{N,Int} : typeof(dims[1])}()
     else
-        ChebyshevUTransformPlan{T,1,kindtuple(UFIRSTKIND,N,dims...)}(FFTW.plan_r2r(x, UFIRSTKIND, dims...; kws...))
+        ChebyshevUTransformPlan{T,1}(FFTW.plan_r2r(x, UFIRSTKIND, dims...; kws...))
     end
 end
 function plan_chebyshevutransform(x::AbstractArray{T,N}, ::Val{2}, dims...; kws...) where {T<:fftwNumber,N}
     any(≤(1),size(x)) && throw(ArgumentError("Array must contain at least 2 entries"))
-    ChebyshevUTransformPlan{T,2,kindtuple(USECONDKIND,N,dims...)}(FFTW.plan_r2r(x, USECONDKIND, dims...; kws...))
+    ChebyshevUTransformPlan{T,2}(FFTW.plan_r2r(x, USECONDKIND, dims...; kws...))
 end
 
 plan_chebyshevutransform!(x::AbstractArray, dims...; kws...) = plan_chebyshevutransform!(x, Val(1), dims...; kws...)
@@ -506,31 +506,31 @@ struct IChebyshevUTransformPlan{T,kind,K,inplace,N,R} <: ChebyshevPlan{T}
     IChebyshevUTransformPlan{T,kind,K,inplace,N,R}() where {T,kind,K,inplace,N,R} = new{T,kind,K,inplace,N,R}()
 end
 
-IChebyshevUTransformPlan{T,kind,K}(F::FFTW.r2rFFTWPlan{T,K,inplace,N,R}) where {T,kind,K,inplace,N,R} =
+IChebyshevUTransformPlan{T,kind}(F::FFTW.r2rFFTWPlan{T,K,inplace,N,R}) where {T,kind,K,inplace,N,R} =
     IChebyshevUTransformPlan{T,kind,K,inplace,N,R}(F)
 
 function plan_ichebyshevutransform!(x::AbstractArray{T,N}, ::Val{1}, dims...; kws...) where {T<:fftwNumber,N}
     if isempty(x)
-        IChebyshevUTransformPlan{T,1,kindtuple(IUFIRSTKIND,N,dims...),true,N,isempty(dims) ? UnitRange{Int} : typeof(dims)}()
+        IChebyshevUTransformPlan{T,1,kindtuple(N,dims...),true,N,isempty(dims) ? NTuple{N,Int} : typeof(dims[1])}()
     else
-        IChebyshevUTransformPlan{T,1,kindtuple(IUFIRSTKIND,N,dims...)}(FFTW.plan_r2r!(x, IUFIRSTKIND, dims...; kws...))
+        IChebyshevUTransformPlan{T,1}(FFTW.plan_r2r!(x, IUFIRSTKIND, dims...; kws...))
     end
 end
 function plan_ichebyshevutransform!(x::AbstractArray{T,N}, ::Val{2}, dims...; kws...) where {T<:fftwNumber,N}
     any(≤(1),size(x)) && throw(ArgumentError("Array must contain at least 2 entries"))
-    IChebyshevUTransformPlan{T,2,kindtuple(USECONDKIND,N,dims...)}(FFTW.plan_r2r!(x, USECONDKIND))
+    IChebyshevUTransformPlan{T,2}(FFTW.plan_r2r!(x, USECONDKIND))
 end
 
 function plan_ichebyshevutransform(x::AbstractArray{T,N}, ::Val{1}, dims...; kws...) where {T<:fftwNumber,N}
     if isempty(x)
-        IChebyshevUTransformPlan{T,1,kindtuple(IUFIRSTKIND,N,dims...),false,N,isempty(dims) ? UnitRange{Int} : typeof(dims)}()
+        IChebyshevUTransformPlan{T,1,kindtuple(N,dims...),false,N,isempty(dims) ? NTuple{N,Int} : typeof(dims[1])}()
     else
-        IChebyshevUTransformPlan{T,1,kindtuple(IUFIRSTKIND,N,dims...)}(FFTW.plan_r2r(x, IUFIRSTKIND, dims...; kws...))
+        IChebyshevUTransformPlan{T,1}(FFTW.plan_r2r(x, IUFIRSTKIND, dims...; kws...))
     end
 end
 function plan_ichebyshevutransform(x::AbstractArray{T,N}, ::Val{2}, dims...; kws...) where {T<:fftwNumber,N}
     any(≤(1),size(x)) && throw(ArgumentError("Array must contain at least 2 entries"))
-    IChebyshevUTransformPlan{T,2,kindtuple(USECONDKIND,N,dims...)}(FFTW.plan_r2r(x, USECONDKIND, dims...; kws...))
+    IChebyshevUTransformPlan{T,2}(FFTW.plan_r2r(x, USECONDKIND, dims...; kws...))
 end
 
 
@@ -539,11 +539,11 @@ plan_ichebyshevutransform(x::AbstractArray, dims...; kws...) = plan_ichebyshevut
 
 # second kind Chebyshev transforms share a plan with their inverse
 # so we support this via inv
-inv(P::ChebyshevUTransformPlan{T,2,K}) where {T,K} = IChebyshevUTransformPlan{T,2,K}(P.plan)
-inv(P::IChebyshevUTransformPlan{T,2,K}) where {T,K} = ChebyshevUTransformPlan{T,2,K}(P.plan)
+inv(P::ChebyshevUTransformPlan{T,2}) where {T} = IChebyshevUTransformPlan{T,2}(P.plan)
+inv(P::IChebyshevUTransformPlan{T,2}) where {T} = ChebyshevUTransformPlan{T,2}(P.plan)
 
-inv(P::ChebyshevUTransformPlan{T,1,K,inplace,N}) where {T,K,inplace,N} = IChebyshevUTransformPlan{T,1,kindtuple(IUFIRSTKIND,N,P.plan.region...)}(inv(P.plan).p)
-inv(P::IChebyshevUTransformPlan{T,1,K,inplace,N}) where {T,K,inplace,N} = ChebyshevUTransformPlan{T,1,kindtuple(UFIRSTKIND,N,P.plan.region...)}(inv(P.plan).p)
+inv(P::ChebyshevUTransformPlan{T,1}) where {T} = IChebyshevUTransformPlan{T,1}(inv(P.plan).p)
+inv(P::IChebyshevUTransformPlan{T,1}) where {T} = ChebyshevUTransformPlan{T,1}(inv(P.plan).p)
 
 
 function _ichebyu1_postscale!(_, x::AbstractVector{T}) where T

--- a/src/chebyshevtransform.jl
+++ b/src/chebyshevtransform.jl
@@ -19,7 +19,7 @@ ChebyshevTransformPlan{T,kind}(plan::FFTW.r2rFFTWPlan{T,K,inplace,N,R}) where {T
     ChebyshevTransformPlan{T,kind,K,inplace,N,R}(plan)
 
 # jump through some hoops to make inferrable
-@inline kindtuple(N) = typeof(ntuple(Int32,N))
+@inline kindtuple(N) = NTuple{N,Int32}
 @inline kindtuple(N,region...) = Vector{Int32}
 function plan_chebyshevtransform!(x::AbstractArray{T,N}, ::Val{1}, dims...; kws...) where {T<:fftwNumber,N}
     if isempty(x)

--- a/test/chebyshevtests.jl
+++ b/test/chebyshevtests.jl
@@ -23,30 +23,50 @@ using FastTransforms, Test
             n = 20
             p_1 = chebyshevpoints(T, n)
             f = exp.(p_1)
-            f̌ = @inferred(chebyshevtransform(f))
-            @test f̌ == chebyshevtransform!(copy(f))
+            g = @inferred(chebyshevtransform(f))
+            @test g == chebyshevtransform!(copy(f))
 
-            f̃ = x -> [cos(k*acos(x)) for k=0:n-1]' * f̌
+            f̃ = x -> [cos(k*acos(x)) for k=0:n-1]' * g
             @test f̃(0.1) ≈ exp(T(0.1))
-            @test @inferred(ichebyshevtransform(f̌)) ≈ ichebyshevtransform!(copy(f̌)) ≈ exp.(p_1)
+            @test @inferred(ichebyshevtransform(g)) ≈ ichebyshevtransform!(copy(g)) ≈ exp.(p_1)
 
-            f̃ = copy(f)
-            f̄ = copy(f̌)
+            fcopy = copy(f)
+            gcopy = copy(g)
             P = @inferred(plan_chebyshevtransform(f))
-            @test @inferred(P*f) == f̌
-            @test f == f̃
+            @test @inferred(P*f) == g
+            @test f == fcopy
             @test_throws ArgumentError P * T[1,2]
+            P2 = @inferred(plan_chebyshevtransform(f, Val(1), 1:1))
+            @test @inferred(P2*f) == g
+            @test_throws ArgumentError P * T[1,2]
+
             P = @inferred(plan_chebyshevtransform!(f))
-            @test @inferred(P*f) == f̌
-            @test f == f̌
+            @test @inferred(P*f) == g
+            @test f == g
             @test_throws ArgumentError P * T[1,2]
-            Pi = @inferred(plan_ichebyshevtransform(f̌))
-            @test @inferred(Pi*f̌) ≈ f̃
-            @test f̌ == f̄
+            f .= fcopy
+            P2 = @inferred(plan_chebyshevtransform!(f, 1:1))
+            @test @inferred(P2*f) == g
+            @test f == g
+            @test_throws ArgumentError P * T[1,2]
+
+            Pi = @inferred(plan_ichebyshevtransform(g))
+            @test @inferred(Pi*g) ≈ fcopy
+            @test g == gcopy
             @test_throws ArgumentError Pi * T[1,2]
-            Pi = @inferred(plan_ichebyshevtransform!(f̌))
-            @test @inferred(Pi*f̌) ≈ f̃
-            @test f̌ ≈ f̃
+            Pi2 = @inferred(plan_ichebyshevtransform(g, 1:1))
+            @test @inferred(Pi2*g) ≈ fcopy
+            @test g == gcopy
+            @test_throws ArgumentError Pi * T[1,2]
+
+            Pi = @inferred(plan_ichebyshevtransform!(g))
+            @test @inferred(Pi*g) ≈ fcopy
+            @test g ≈ fcopy
+            g .= gcopy
+            @test_throws ArgumentError Pi * T[1,2]
+            Pi2 = @inferred(plan_ichebyshevtransform!(g, 1:1))
+            @test @inferred(Pi2*g) ≈ fcopy
+            @test g ≈ fcopy
             @test_throws ArgumentError Pi * T[1,2]
 
             @test chebyshevtransform(T[1]) == T[1]
@@ -60,36 +80,58 @@ using FastTransforms, Test
             n = 20
             p_2 = chebyshevpoints(T, n, Val(2))
             f = exp.(p_2)
-            f̌ = @inferred(chebyshevtransform(f, Val(2)))
-            @test f̌ == chebyshevtransform!(copy(f), Val(2))
+            g = @inferred(chebyshevtransform(f, Val(2)))
+            @test g == chebyshevtransform!(copy(f), Val(2))
 
-            f̃ = x -> [cos(k*acos(x)) for k=0:n-1]' * f̌
+            f̃ = x -> [cos(k*acos(x)) for k=0:n-1]' * g
             @test f̃(0.1) ≈ exp(T(0.1))
-            @test @inferred(ichebyshevtransform(f̌, Val(2))) ≈ ichebyshevtransform!(copy(f̌), Val(2)) ≈ exp.(p_2)
+            @test @inferred(ichebyshevtransform(g, Val(2))) ≈ ichebyshevtransform!(copy(g), Val(2)) ≈ exp.(p_2)
 
             P = @inferred(plan_chebyshevtransform!(f, Val(2)))
             Pi = @inferred(plan_ichebyshevtransform!(f, Val(2)))
             @test all(@inferred(P \ copy(f)) .=== Pi * copy(f))
-            @test all(@inferred(Pi \ copy(f̌)) .=== P * copy(f̌))
+            @test all(@inferred(Pi \ copy(g)) .=== P * copy(g))
             @test f ≈ P \ (P*copy(f)) ≈ P * (P\copy(f)) ≈ Pi \ (Pi*copy(f)) ≈ Pi * (Pi \ copy(f))
 
-            f̃ = copy(f)
-            f̄ = copy(f̌)
+            fcopy = copy(f)
+            gcopy = copy(g)
+
             P = @inferred(plan_chebyshevtransform(f, Val(2)))
+            @test P*f == g
+            @test f == fcopy
             @test_throws ArgumentError P * T[1,2]
-            @test P*f == f̌
-            @test f == f̃
+            P = @inferred(plan_chebyshevtransform(f, Val(2), 1:1))
+            @test P*f == g
+            @test f == fcopy
+            @test_throws ArgumentError P * T[1,2]
+
             P = @inferred(plan_chebyshevtransform!(f, Val(2)))
-            @test P*f == f̌
-            @test f == f̌
+            @test P*f == g
+            @test f == g
             @test_throws ArgumentError P * T[1,2]
-            Pi = @inferred(plan_ichebyshevtransform(f̌, Val(2)))
-            @test Pi*f̌ ≈ f̃
-            @test f̌ == f̄
+            f .= fcopy
+            P = @inferred(plan_chebyshevtransform!(f, Val(2), 1:1))
+            @test P*f == g
+            @test f == g
+            @test_throws ArgumentError P * T[1,2]
+
+            Pi = @inferred(plan_ichebyshevtransform(g, Val(2)))
+            @test Pi*g ≈ fcopy
+            @test g == gcopy
             @test_throws ArgumentError Pi * T[1,2]
-            Pi = @inferred(plan_ichebyshevtransform!(f̌, Val(2)))
-            @test Pi*f̌ ≈ f̃
-            @test f̌ ≈ f̃
+            Pi = @inferred(plan_ichebyshevtransform(g, Val(2), 1:1))
+            @test Pi*g ≈ fcopy
+            @test g == gcopy
+            @test_throws ArgumentError Pi * T[1,2]
+
+            Pi = @inferred(plan_ichebyshevtransform!(g, Val(2)))
+            @test Pi*g ≈ fcopy
+            @test g ≈ fcopy
+            @test_throws ArgumentError Pi * T[1,2]
+            g .= gcopy
+            Pi = @inferred(plan_ichebyshevtransform!(g, Val(2), 1:1))
+            @test Pi*g ≈ fcopy
+            @test g ≈ fcopy
             @test_throws ArgumentError Pi * T[1,2]
 
             @test_throws ArgumentError chebyshevtransform(T[1], Val(2))
@@ -104,29 +146,50 @@ using FastTransforms, Test
             n = 20
             p_1 = chebyshevpoints(T, n)
             f = exp.(p_1)
-            f̌ = @inferred(chebyshevutransform(f))
+            g = @inferred(chebyshevutransform(f))
 
-            f̃ = x -> [sin((k+1)*acos(x))/sin(acos(x)) for k=0:n-1]' * f̌
+            f̃ = x -> [sin((k+1)*acos(x))/sin(acos(x)) for k=0:n-1]' * g
             @test f̃(0.1) ≈ exp(T(0.1))
-            @test ichebyshevutransform(f̌) ≈ exp.(p_1)
+            @test ichebyshevutransform(g) ≈ exp.(p_1)
 
-            f̃ = copy(f)
-            f̄ = copy(f̌)
+            fcopy = copy(f)
+            gcopy = copy(g)
             P = @inferred(plan_chebyshevutransform(f))
-            @test P*f ≈ f̌
-            @test f == f̃
+            @test P*f ≈ g
+            @test f == fcopy
             @test_throws ArgumentError P * T[1,2]
+            P = @inferred(plan_chebyshevutransform(f, 1:1))
+            @test P*f ≈ g
+            @test f == fcopy
+            @test_throws ArgumentError P * T[1,2]
+
             P = @inferred(plan_chebyshevutransform!(f))
-            @test P*f ≈ f̌
-            @test f ≈ f̌
+            @test P*f ≈ g
+            @test f ≈ g
             @test_throws ArgumentError P * T[1,2]
-            Pi = @inferred(plan_ichebyshevutransform(f̌))
-            @test Pi*f̌ ≈ f̃
-            @test f̌ == f̄
+            f .= fcopy
+            P = @inferred(plan_chebyshevutransform!(f))
+            @test P*f ≈ g
+            @test f ≈ g
+            @test_throws ArgumentError P * T[1,2]
+
+            Pi = @inferred(plan_ichebyshevutransform(g))
+            @test Pi*g ≈ fcopy
+            @test g == gcopy
             @test_throws ArgumentError Pi * T[1,2]
-            Pi = @inferred(plan_ichebyshevutransform!(f̌))
-            @test Pi*f̌ ≈ f̃
-            @test f̌ ≈ f̃
+            Pi = @inferred(plan_ichebyshevutransform(g, 1:1))
+            @test Pi*g ≈ fcopy
+            @test g == gcopy
+            @test_throws ArgumentError Pi * T[1,2]
+
+            Pi = @inferred(plan_ichebyshevutransform!(g))
+            @test Pi*g ≈ fcopy
+            @test g ≈ fcopy
+            @test_throws ArgumentError Pi * T[1,2]
+            g .= gcopy
+            Pi = @inferred(plan_ichebyshevutransform!(g))
+            @test Pi*g ≈ fcopy
+            @test g ≈ fcopy
             @test_throws ArgumentError Pi * T[1,2]
 
             @test chebyshevutransform(T[1]) == T[1]
@@ -140,29 +203,46 @@ using FastTransforms, Test
             n = 20
             p_2 = chebyshevpoints(T, n, Val(2))[2:end-1]
             f = exp.(p_2)
-            f̌ = @inferred(chebyshevutransform(f, Val(2)))
+            g = @inferred(chebyshevutransform(f, Val(2)))
 
-            f̃ = x -> [sin((k+1)*acos(x))/sin(acos(x)) for k=0:n-3]' * f̌
+            f̃ = x -> [sin((k+1)*acos(x))/sin(acos(x)) for k=0:n-3]' * g
             @test f̃(0.1) ≈ exp(T(0.1))
-            @test @inferred(ichebyshevutransform(f̌, Val(2))) ≈ exp.(p_2)
+            @test @inferred(ichebyshevutransform(g, Val(2))) ≈ exp.(p_2)
 
-            f̃ = copy(f)
-            f̄ = copy(f̌)
+            fcopy = copy(f)
+            gcopy = copy(g)
             P = @inferred(plan_chebyshevutransform(f, Val(2)))
-            @test @inferred(P*f) ≈ f̌
-            @test f ≈ f̃
+            @test @inferred(P*f) ≈ g
+            @test f ≈ fcopy
             @test_throws ArgumentError P * T[1,2]
+            P = @inferred(plan_chebyshevutransform(f, Val(2), 1:1))
+            @test @inferred(P*f) ≈ g
+            @test f ≈ fcopy
+            @test_throws ArgumentError P * T[1,2]
+
             P = @inferred(plan_chebyshevutransform!(f, Val(2)))
-            @test @inferred(P*f) ≈ f̌
-            @test f ≈ f̌
+            @test @inferred(P*f) ≈ g
+            @test f ≈ g
             @test_throws ArgumentError P * T[1,2]
-            Pi = @inferred(plan_ichebyshevutransform(f̌, Val(2)))
-            @test @inferred(Pi*f̌) ≈ f̃
-            @test f̌ ≈ f̄
+            f .= fcopy
+            P = @inferred(plan_chebyshevutransform!(f, Val(2), 1:1))
+            @test @inferred(P*f) ≈ g
+            @test f ≈ g
+            @test_throws ArgumentError P * T[1,2]
+
+            Pi = @inferred(plan_ichebyshevutransform(g, Val(2)))
+            @test @inferred(Pi*g) ≈ fcopy
+            @test g ≈ gcopy
             @test_throws ArgumentError Pi * T[1,2]
-            Pi = @inferred(plan_ichebyshevutransform!(f̌, Val(2)))
-            @test @inferred(Pi*f̌) ≈ f̃
-            @test f̌ ≈ f̃
+
+            Pi = @inferred(plan_ichebyshevutransform!(g, Val(2)))
+            @test @inferred(Pi*g) ≈ fcopy
+            @test g ≈ fcopy
+            @test_throws ArgumentError Pi * T[1,2]
+            g .= gcopy
+            Pi = @inferred(plan_ichebyshevutransform!(g, Val(2)))
+            @test @inferred(Pi*g) ≈ fcopy
+            @test g ≈ fcopy
             @test_throws ArgumentError Pi * T[1,2]
 
             @test_throws ArgumentError chebyshevutransform(T[1], Val(2))


### PR DESCRIPTION
The main change in FFTW is that instead of the values of `kinds` being a type-parameter, it's stored as a struct field. This helps with type-stability.

I've renamed some of the variables in the tests, as this improved readability.

Test failures on Windows are seen on https://github.com/JuliaApproximation/FastTransforms.jl/pull/192 as well, so it's likely unrelated to this PR.

