### PR TITLE
revert to libfasttransforms as default

### DIFF
--- a/src/FastTransforms.jl
+++ b/src/FastTransforms.jl
@@ -118,20 +118,21 @@ for f in (:jac2jac,
     :cheb2jac, :ultra2cheb, :cheb2ultra, :associatedjac2jac,
     :modifiedjac2jac, :modifiedlag2lag, :modifiedherm2herm,
     :sph2fourier, :sphv2fourier, :disk2cxf, :ann2cxf,
-    :rectdisk2cheb, :tri2cheb, :tet2cheb)
+    :rectdisk2cheb, :tri2cheb, :tet2cheb,
+    :leg2cheb, :cheb2leg, :ultra2ultra)
     lib_f = Symbol("lib_", f)
     @eval $f(x::AbstractArray, y...; z...) = $lib_f(x, y...; z...)
 end
 
 # following use Toeplitz-Hankel to avoid expensive plans
-for f in (:leg2cheb, :cheb2leg, :ultra2ultra)
-    th_f = Symbol("th_", f)
-    lib_f = Symbol("lib_", f)
-    @eval begin
-        $f(x::AbstractArray, y...; z...) = $th_f(x, y...; z...)
-        # $f(x::AbstractArray, y...; z...) = $lib_f(x, y...; z...)
-    end
-end
+# for f in (:leg2cheb, :cheb2leg, :ultra2ultra)
+#     th_f = Symbol("th_", f)
+#     lib_f = Symbol("lib_", f)
+#     @eval begin
+#         $f(x::AbstractArray, y...; z...) = $th_f(x, y...; z...)
+#         # $f(x::AbstractArray, y...; z...) = $lib_f(x, y...; z...)
+#     end
+# end
 
 
 end # module

--- a/test/toeplitzhankeltests.jl
+++ b/test/toeplitzhankeltests.jl
@@ -12,21 +12,22 @@ import FastTransforms: th_leg2cheb, th_cheb2leg, th_ultra2ultra,th_jac2jac, th_l
         @test th_jac2jac(x,0.1, 0.2,0.1,0.4) ≈ lib_jac2jac(x, 0.1, 0.2,0.1,0.4)
         @test th_jac2jac(x,0.1, 0.2,0.3,0.2) ≈ lib_jac2jac(x, 0.1, 0.2,0.3,0.2)
 
-        @test all(th_leg2cheb(x) .=== leg2cheb(x))
-        @test all(th_cheb2leg(x) .=== cheb2leg(x))
 
         @test th_cheb2leg(th_leg2cheb(x)) ≈ x atol=1E-9
         @test th_leg2cheb(th_cheb2leg(x)) ≈ x atol=1E-10
     end
 
     for X in (randn(5,4), randn(5,4) + im*randn(5,4))
-        @test th_leg2cheb(X, 1) ≈ leg2cheb(X, 1) ≈ hcat([leg2cheb(X[:,j]) for j=1:size(X,2)]...)
-        @test th_leg2cheb(X, 2) ≈ leg2cheb(X, 2) ≈ vcat([permutedims(leg2cheb(X[k,:])) for k=1:size(X,1)]...)
-        @test th_leg2cheb(X) ≈ leg2cheb(X) ≈ th_leg2cheb(th_leg2cheb(X, 1), 2)
+        @test th_leg2cheb(X, 1) ≈ hcat([leg2cheb(X[:,j]) for j=1:size(X,2)]...)
+        @test_broken th_leg2cheb(X, 1) ≈ leg2cheb(X, 1)
+        @test th_leg2cheb(X, 2) ≈ vcat([permutedims(leg2cheb(X[k,:])) for k=1:size(X,1)]...)
+        @test_broken th_leg2cheb(X, 2) ≈ leg2cheb(X, 2)
+        @test th_leg2cheb(X) ≈ th_leg2cheb(th_leg2cheb(X, 1), 2)
+        @test_broken th_leg2cheb(X) ≈ leg2cheb(X)
 
-        @test th_cheb2leg(X, 1) ≈ cheb2leg(X, 1) ≈ hcat([cheb2leg(X[:,j]) for j=1:size(X,2)]...)
-        @test th_cheb2leg(X, 2) ≈ cheb2leg(X, 2) ≈ vcat([permutedims(cheb2leg(X[k,:])) for k=1:size(X,1)]...)
-        @test th_cheb2leg(X) ≈ cheb2leg(X) ≈ th_cheb2leg(th_cheb2leg(X, 1), 2)
+        @test th_cheb2leg(X, 1) ≈ hcat([cheb2leg(X[:,j]) for j=1:size(X,2)]...)
+        @test th_cheb2leg(X, 2) ≈ vcat([permutedims(cheb2leg(X[k,:])) for k=1:size(X,1)]...)
+        @test th_cheb2leg(X) ≈ th_cheb2leg(th_cheb2leg(X, 1), 2)
 
         @test th_cheb2leg(X) == plan_th_cheb2leg!(X, 1:2)*copy(X)
         @test th_leg2cheb(X) == plan_th_leg2cheb!(X, 1:2)*copy(X)
@@ -37,16 +38,16 @@ import FastTransforms: th_leg2cheb, th_cheb2leg, th_ultra2ultra,th_jac2jac, th_l
     @testset "BigFloat" begin
         n = 10
         x = big.(collect(1.0:n))
-        @test leg2cheb(x) ≈ lib_leg2cheb(x)
-        @test cheb2leg(x) ≈ lib_cheb2leg(x)
+        @test th_leg2cheb(x) ≈ lib_leg2cheb(x)
+        @test th_cheb2leg(x) ≈ lib_cheb2leg(x)
     end
 
     @testset "jishnub example" begin
         x = chebyshevpoints(4096);
         f = x -> cospi(1000x);  
         y = f.(x);
-        v = cheb2leg(chebyshevtransform(y))
-        @test norm(v - cheb2leg(leg2cheb(v)), Inf) ≤ 1E-13
-        @test norm(v - cheb2leg(leg2cheb(v)))/norm(v) ≤ 1E-14
+        v = th_cheb2leg(chebyshevtransform(y))
+        @test norm(v - th_cheb2leg(th_leg2cheb(v)), Inf) ≤ 1E-13
+        @test norm(v - th_cheb2leg(th_leg2cheb(v)))/norm(v) ≤ 1E-14
     end
 end


### PR DESCRIPTION
This fixes #206 

We can change to using Toeplitz-dot-Hankel for large vectors later when the interface is refined