### PR TITLE
Fix weird syntax in annulus example

### DIFF
--- a/examples/annulus.jl
+++ b/examples/annulus.jl
@@ -39,7 +39,7 @@ M = 4N-3
 ρ = 2/3
 
 # The radial grid:
-r = [begin t = (N-n-0.5)/(2N); ct = sinpi(t); st = cospi(t); sqrt(ct^2+ρ^2*st^2) end; for n in 0:N-1]
+r = [begin t = (N-n-0.5)/(2N); ct = sinpi(t); st = cospi(t); sqrt(ct^2+ρ^2*st^2) end for n in 0:N-1]
 
 # The angular grid (mod $\pi$):
 θ = (0:M-1)*2/M


### PR DESCRIPTION
Found as part of JuliaLang/julia#46372 - The reference parser allows the trailing semicolon after the block here, but JuliaSyntax.jl rejects it: Having a semicolon within [] would normally imply vcat. But having a semicolon followed by a `for` to make it into a comprehension? That's just... weird :-)