### PR TITLE
Split y coordinate computation in `paduapoints`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FastTransforms"
 uuid = "057dd010-8810-581a-b7be-e3fc3b93f78c"
-version = "0.15.6"
+version = "0.15.7"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/PaduaTransform.jl
+++ b/src/PaduaTransform.jl
@@ -209,14 +209,14 @@ function paduapoints(::Type{T}, n::Integer) where T
     MM=Matrix{T}(undef,N,2)
     m=0
     delta=0
-    NN=fld(n+2,2)
+    NN=div(n,2)+1
     # x coordinates
     for k=n:-1:0
         if isodd(n)
             delta = Int(isodd(k))
         end
         x = -cospi(T(k)/n)
-        for j=NN+delta:-1:1
+        @inbounds for j=NN+delta:-1:1
             m+=1
             MM[m,1]=x
         end
@@ -230,7 +230,7 @@ function paduapoints(::Type{T}, n::Integer) where T
         end
         for j=NN+delta:-1:1
             m+=1
-            if isodd(n-k)
+            @inbounds if isodd(n-k)
                 MM[m,2]=-cospi((2j-one(T))/(n+1))
             else
                 MM[m,2]=-cospi(T(2j-2)/(n+1))
@@ -238,13 +238,14 @@ function paduapoints(::Type{T}, n::Integer) where T
         end
     end
     m += 1
+    # number of y coordinates between k=n and k=n-2
+    Ny_shift = 2NN+isodd(n)
     for k in n-2:-1:0
         if isodd(n)
             delta = Int(isodd(k))
         end
-        NNk = 2NN+isodd(n)
         for j in range(m, length=NN+delta)
-            MM[j,2] = MM[j-NNk,2]
+            @inbounds MM[j,2] = MM[j-Ny_shift,2]
         end
         m += NN+delta
     end

--- a/src/PaduaTransform.jl
+++ b/src/PaduaTransform.jl
@@ -210,19 +210,43 @@ function paduapoints(::Type{T}, n::Integer) where T
     m=0
     delta=0
     NN=fld(n+2,2)
-    @inbounds for k=n:-1:0
-        if isodd(n)>0
-            delta=mod(k,2)
+    # x coordinates
+    for k=n:-1:0
+        if isodd(n)
+            delta = Int(isodd(k))
         end
-        @inbounds for j=NN+delta:-1:1
+        x = -cospi(T(k)/n)
+        for j=NN+delta:-1:1
             m+=1
-            MM[m,1]=sinpi(T(k)/n-T(0.5))
-            if isodd(n-k)>0
-                MM[m,2]=sinpi((2j-one(T))/(n+1)-T(0.5))
+            MM[m,1]=x
+        end
+    end
+    # y coordinates
+    # populate the first two sets, and copy the rest
+    m=0
+    for k=n:-1:n-1
+        if isodd(n)
+            delta = Int(isodd(k))
+        end
+        for j=NN+delta:-1:1
+            m+=1
+            if isodd(n-k)
+                MM[m,2]=-cospi((2j-one(T))/(n+1))
             else
-                MM[m,2]=sinpi(T(2j-2)/(n+1)-T(0.5))
+                MM[m,2]=-cospi(T(2j-2)/(n+1))
             end
         end
+    end
+    m += 1
+    for k in n-2:-1:0
+        if isodd(n)
+            delta = Int(isodd(k))
+        end
+        NNk = 2NN+isodd(n)
+        for j in range(m, length=NN+delta)
+            MM[j,2] = MM[j-NNk,2]
+        end
+        m += NN+delta
     end
     return MM
 end

--- a/test/paduatests.jl
+++ b/test/paduatests.jl
@@ -53,4 +53,17 @@ using FastTransforms, Test
     g_l=paduaeval(g_xy,x,y,l,Val{false})
     @test f_xy(x,y) ≈ f_m
     @test g_xy(x,y) ≈ g_l
+
+    # odd n
+    m=135
+    l=85
+    f_m=paduaeval(f_xy,x,y,m,Val{true})
+    g_l=paduaeval(g_xy,x,y,l,Val{true})
+    @test f_xy(x,y) ≈ f_m
+    @test g_xy(x,y) ≈ g_l
+
+    f_m=paduaeval(f_xy,x,y,m,Val{false})
+    g_l=paduaeval(g_xy,x,y,l,Val{false})
+    @test f_xy(x,y) ≈ f_m
+    @test g_xy(x,y) ≈ g_l
 end


### PR DESCRIPTION
The main change is recognizing that we only need to evaluate the x coordinates once for each `k`, and the `y` coordinates for `k=n-1:n` and copy the values for the other `k`. This greatly reduces the number of transcendental function calls, and speeds up `paduapoints` considerably.
On master
```julia
julia> @btime FastTransforms.paduapoints(100);
  160.437 μs (2 allocations: 80.55 KiB)
```
This PR
```julia
julia> @btime FastTransforms.paduapoints(100);
  9.378 μs (2 allocations: 80.55 KiB)
```