### PR TITLE
Use a mutable copy of input if inplace scaling is required

### DIFF
--- a/src/chebyshevtransform.jl
+++ b/src/chebyshevtransform.jl
@@ -51,8 +51,9 @@ end
 
 
 # convert x if necessary
-@inline _plan_mul!(y::AbstractArray{T}, P::Plan{T}, x::StridedArray{T}) where T = mul!(y, P, x)
-@inline _plan_mul!(y::AbstractArray{T}, P::Plan{T}, x::AbstractArray) where T = mul!(y, P, convert(Array{T}, x))
+_maybemutablecopy(x::StridedArray{T}, ::Type{T}) where {T} = x
+_maybemutablecopy(x, T) = copyto!(similar(x, T), x)
+@inline _plan_mul!(y::AbstractArray{T}, P::Plan{T}, x::StridedArray{T}) where T = mul!(y, P, _maybemutablecopy(x, T))
 
 
 for op in (:ldiv, :lmul)
@@ -311,7 +312,8 @@ function mul!(y::AbstractArray{T,N}, P::IChebyshevTransformPlan{T,2,K,false,N}, 
     _icheb2_rescale!(P.plan.region, y)
 end
 
-*(P::IChebyshevTransformPlan{T,kind,K,false,N}, x::AbstractArray{T,N}) where {T,kind,K,N} = mul!(similar(x), P, x)
+*(P::IChebyshevTransformPlan{T,kind,K,false,N}, x::AbstractArray{T,N}) where {T,kind,K,N} =
+    mul!(similar(x), P, _maybemutablecopy(x, T))
 ichebyshevtransform!(x::AbstractArray, dims...; kwds...) = plan_ichebyshevtransform!(x, dims...; kwds...)*x
 ichebyshevtransform(x, dims...; kwds...) = plan_ichebyshevtransform(x, dims...; kwds...)*x
 

--- a/src/chebyshevtransform.jl
+++ b/src/chebyshevtransform.jl
@@ -53,7 +53,7 @@ end
 # convert x if necessary
 _maybemutablecopy(x::StridedArray{T}, ::Type{T}) where {T} = x
 _maybemutablecopy(x, T) = Array{T}(x)
-@inline _plan_mul!(y::AbstractArray{T}, P::Plan{T}, x::StridedArray{T}) where T = mul!(y, P, _maybemutablecopy(x, T))
+@inline _plan_mul!(y::AbstractArray{T}, P::Plan{T}, x::AbstractArray) where T = mul!(y, P, _maybemutablecopy(x, T))
 
 
 for op in (:ldiv, :lmul)

--- a/src/chebyshevtransform.jl
+++ b/src/chebyshevtransform.jl
@@ -52,7 +52,7 @@ end
 
 # convert x if necessary
 _maybemutablecopy(x::StridedArray{T}, ::Type{T}) where {T} = x
-_maybemutablecopy(x, T) = copyto!(similar(x, T), x)
+_maybemutablecopy(x, T) = Array{T}(x)
 @inline _plan_mul!(y::AbstractArray{T}, P::Plan{T}, x::StridedArray{T}) where T = mul!(y, P, _maybemutablecopy(x, T))
 
 

--- a/test/chebyshevtests.jl
+++ b/test/chebyshevtests.jl
@@ -447,6 +447,7 @@ using FastTransforms, Test
     @testset "immutable vectors" begin
         F = plan_chebyshevtransform([1.,2,3])
         @test chebyshevtransform(1.0:3) == F * (1:3)
+        @test ichebyshevtransform(1.0:3) == ichebyshevtransform([1.0:3;])
     end
 
     @testset "inv" begin


### PR DESCRIPTION
This fixes the inverse Chebyshev transform for immutable input vectors. The following works now:
```julia
julia> ichebyshevtransform(1.0:4.0)
4-element Vector{Float64}:
  6.499813138042575
 -4.05147160887461
  1.808830921755324
 -0.25717245092328955
```
This throws an error on master, as the input doesn't support in-place assignment.