### PR TITLE
Fix type-promotion in BigInt transforms

### DIFF
--- a/src/chebyshevtransform.jl
+++ b/src/chebyshevtransform.jl
@@ -598,7 +598,7 @@ ichebyshevutransform(x, dims...; kwds...) = plan_ichebyshevutransform(x, dims...
 ## Code generation for integer inputs
 
 for func in (:chebyshevtransform,:ichebyshevtransform,:chebyshevutransform,:ichebyshevutransform)
-    @eval $func(x::AbstractVector{T}, dims...; kwds...) where {T<:Integer} = $func(convert(AbstractVector{Float64},x), dims...; kwds...)
+    @eval $func(x::AbstractVector{T}, dims...; kwds...) where {T<:Integer} = $func(convert(AbstractVector{float(T)},x), dims...; kwds...)
 end
 
 

--- a/test/chebyshevtests.jl
+++ b/test/chebyshevtests.jl
@@ -443,6 +443,10 @@ using FastTransforms, Test
         @test plan_chebyshevtransform!(x)copy(x) ≈ chebyshevtransform(x)
         @test plan_ichebyshevtransform!(x)copy(x) ≈ ichebyshevtransform(x)
     end
+    @testset "BigInt" begin
+        x = big(10)^400 .+ BigInt[1,2,3]
+        @test ichebyshevtransform(chebyshevtransform(x)) ≈ x
+    end
 
     @testset "immutable vectors" begin
         F = plan_chebyshevtransform([1.,2,3])


### PR DESCRIPTION
On master
```julia
julia> r = big(10)^400 .+ (0:1);

julia> chebyshevtransform(r)
2-element Vector{Float64}:
  Inf
 NaN
```
This PR fixes this.